### PR TITLE
[celery] graceful shutdown of worker threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN apk add --no-cache \
         curl-dev
 
 RUN pip install --no-cache-dir \
+        celery-graceful-stop \
         cabot-check-sslcert \
         cabot-alert-slack \
         https://github.com/cabotapp/cabot-check-network/archive/master.zip \
         https://github.com/JorgenEvens/cabot-check-smtp/archive/master.zip \
         ;
+
+RUN echo $'import celery_graceful_stop\ncelery_graceful_stop.register(app)' \
+     >> /usr/local/lib/python2.7/site-packages/cabot/celery.py
 
 ADD aio-launch /aio-launch


### PR DESCRIPTION
When Heroku restarts a dyno the worker threads should be allowed to
finish the checks that are in flight, rather than cause false positives.

This PR adds https://pypi.org/project/celery-graceful-stop/ which should
provide this.